### PR TITLE
fix(android): image-crop openAsset signature diff

### DIFF
--- a/src/android/capacitor-image-crop/src/main/java/co/fitcom/capacitor/ImageCropPlugin.java
+++ b/src/android/capacitor-image-crop/src/main/java/co/fitcom/capacitor/ImageCropPlugin.java
@@ -62,7 +62,7 @@ public class ImageCropPlugin extends Plugin {
         AndroidProtocolHandler protocolHandler = new AndroidProtocolHandler(getActivity().getApplicationContext());
         try {
             File f = new File("file:///android_asset/public" + source);
-           InputStream is = protocolHandler.openAsset("public" + source,"");
+            InputStream is = protocolHandler.openAsset("public" + source);
             File tempSource = new File(getActivity().getCacheDir().getAbsolutePath() + f.getName());
             FileOutputStream os = new FileOutputStream(tempSource);
             IOUtils.copy(is,os);


### PR DESCRIPTION
Resolves error related to:
```
error: method openAsset in class AndroidProtocolHandler cannot be applied to given types;
required: String
found: String,String
reason: actual and formal argument lists differ in length
```